### PR TITLE
Adding a link to Priceops.org

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,8 @@ Billing is one of the transversal pillar of the ecosystem, where customers, prod
 
 This highlight the strategic importance of the domain, not only for cloud providers but virtually any business, especially those who are software-centric.
 
+- [PriceOps.org](https://priceops.org) - The 5 Pillars of PriceOps define a methodology for pricing model definition and implementation that supports iteration, safety, and organizational alignment.
+
 - [Pricing, my only growth hack at Qonto](https://getlago.substack.com/p/pricing-my-only-growth-hack-at-qonto?s=r) - Most businesses don't know how to iterate over pricing: sales teams dictates them without involvement of the people in charge of implementation, which ends up in frustration for all. That's why you need to recognize billing as a critical function of your organization.
 
 - [5 things I learned while developing a billing system](https://arnon.dk/5-things-i-learned-developing-billing-system/) - A great introduction on all the various aspects of a billing system, from currency to invoices, including great illustrations about plans change logic. All these topics are later detailed in dedicated sections below.


### PR DESCRIPTION
#### Preliminary checks

- [x ] I have [read the Code of Conduct](https://github.com/kdeldycke/awesome-billing/blob/main/.github/code-of-conduct.md)
- [ x] I applied all rules from the [Contributing guide](https://github.com/kdeldycke/awesome-billing/blob/main/.github/contributing.md)
- [x ] I have checked there is not other [Issues](https://github.com/kdeldycke/awesome-billing/issues) or [Pull Requests](https://github.com/kdeldycke/awesome-billing/pulls) covering the same topic to open

#### Summary

<!-- You can skip this if you're proposing something as trivial as fixing a typo -->

Explain the motivation for making this change. What does does this bring to the table?

Priceops is often useful for developers and the people who work with them to implement pricing, make pricing changes, and manage metering, billing, etc systems. It provides an outline of how to approach pricing and its related areas of concern. 
 