### PR TITLE
Add `eu-vat-rates-data` to European VAT section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -419,6 +419,8 @@ All the invoicing terms & conditions are materialzed by the contract signed betw
 
 ### European VAT
 
+- [eu-vat-rates-data](https://github.com/vatnode/eu-vat-rates-data-js) - EU VAT rates for all 27 member states + UK, fetched daily from the official European Commission TEDB and published automatically when rates change. Available for JavaScript, Python, PHP, Go, and Ruby.
+
 - [How to correctly setup SaaS subscriptions to charge VAT in Europe](https://medium.com/slight-pause/how-to-setup-saas-subscriptions-correctly-to-charge-vat-in-europe-d75d857b5d01) - “If you think you can just setup a simple Stripe integration and move on, like us, you'd be sadly mistaken.”
 
 <!--lint disable double-link-->


### PR DESCRIPTION
## What

Adds [eu-vat-rates-data](https://github.com/vatnode/eu-vat-rates-data-js) to the European VAT section.

## Why it fits

This is a developer library that provides EU VAT rates for all 27 member states + UK:

- Fetched daily from the **official European Commission TEDB** (not hardcoded)
- Published automatically via GitHub Actions when rates change
- Available in 5 ecosystems: JavaScript/TypeScript, Python, PHP, Go, Ruby
- MIT license, zero dependencies
- Full audit trail via git history

It's the only package in this space with automated daily updates from an official source — all alternatives are either abandoned or manually maintained.

## Links

- npm: https://www.npmjs.com/package/eu-vat-rates-data
- PyPI: https://pypi.org/project/eu-vat-rates-data/
- GitHub: https://github.com/vatnode/eu-vat-rates-data-js