### PR TITLE
Add VerdeDesk - Portugal freelancer tax tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -429,6 +429,8 @@ All the invoicing terms & conditions are materialzed by the contract signed betw
 
 - [What does the "Reverse Charge" refer to?](https://news.ycombinator.com/item?id=8767388) - Answer: a provision in which a business transfer the responsibility of VAT handling to the customer.
 
+- [VerdeDesk](https://verdedesk.vercel.app) - Free Portugal freelancer tax guides and calculator covering IRS, VAT, social security, and green receipts (recibos verdes) for self-employed workers.
+
 ## Invoice
 
 The invoice materialize a consumed service or purchased product, waiting to be settled by a payment transaction.


### PR DESCRIPTION
## What this PR adds

Adds [VerdeDesk](https://verdedesk.vercel.app) to the European VAT section.

VerdeDesk provides free English-language guides and calculators for freelancers in Portugal, covering:
- **IRS** (income tax) obligations and filing
- **VAT** (IVA) rules for self-employed workers
- **Social security** (Seguranca Social) contributions
- **Green receipts** (recibos verdes) — the Portuguese self-employment invoice system

## Why it belongs here

Portugal has a growing freelancer population (D8 visa holders, expats, digital nomads) who must navigate a Portuguese-only tax portal (Portal das Financas). VerdeDesk is a free resource that explains the European VAT and invoicing requirements specific to Portuguese freelancers, which is directly relevant to the billing and tax domain covered by this list.