### PR TITLE
Add eleata Peppol API to Electronic invoices

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -485,6 +485,8 @@ Once issued, an invoice must be immutable.
 
 - [GOBL](https://github.com/invopop/gobl) - 💸 JSON Schema, Open Source Go library, global tax database, with conversion tools, all in one. Invopop sells a managed e-invoicing SaaS implementation on top of the open spec.
 
+- [eleata Peppol API](https://peppol.eleata.io) - 💸 Hosted REST API + SDKs (Node, Python, Go) + GitHub Action wrapping Mustang for Peppol BIS 3, XRechnung, Factur-X (with native PDF/A-3 extraction), and UBL validation. Complements the self-hosted libraries already listed by adding a CI-friendly endpoint without a JVM dependency. Free tier 200/month.
+
 ## Payments
 
 - [The Best Payment Gateway for Startups](https://web.archive.org/web/20230204235716/http://aynuriev.com/best-payment-gateway-startups/) - A benchmark of top payment providers, their pricing and models.


### PR DESCRIPTION
## What's added

A single entry under **Invoice → Electronic invoices**:

> - [eleata Peppol API](https://peppol.eleata.io) - 💸 Hosted REST API + SDKs (Node, Python, Go) + GitHub Action wrapping Mustang for Peppol BIS 3, XRechnung, Factur-X (with native PDF/A-3 extraction), and UBL validation. Complements the self-hosted libraries already listed by adding a CI-friendly endpoint without a JVM dependency. Free tier 200/month.

## Why it adds to the existing corpus

The Electronic invoices section currently lists:
- **Invoice Security Vulnerabilities** — security article
- **EU eInvoicing** — official EU portal
- **Factur-X** — Python library by akretion
- **Universal Business Language** — Wikipedia entry on the spec
- **GOBL** — Go library + Invopop's hosted SaaS

What is missing: a **CI-friendly hosted endpoint** that developers can hit without spinning up a JVM. Both major reference engines (Mustang, phive) ship as Java JARs or web forms only; integrating them into a non-JVM CI pipeline or an ERP/SaaS deployed in a container without Java is non-trivial.

eleata exposes Mustang 2.23.0 over HTTPS with idiomatic SDKs for Node, Python, and Go, plus a GitHub Action — covering the gap between \"there is a Schematron rule set\" and \"my CI fails when an outgoing invoice would be rejected by a Peppol Access Point.\"

## Format

- HTTPS source: <https://peppol.eleata.io>
- Free tier confirmed: 200 validations/month, no card required (verifiable at <https://peppol.eleata.io/signup/>)
- Indicated with 💸 (paid SaaS with free tier) following the convention used for GOBL
- Inserted after GOBL within the Electronic invoices group

## Self-checks

- [x] One list item per commit
- [x] One commit per PR
- [x] Spelling/grammar checked
- [x] Reason-why-awesome explained above
- [x] Linked resource is a hosted service, not a low-traction GitHub repo (50-star rule N/A)
- [x] Translated readme files: there are no `readme.*.md` translation variants in the repo at this time

Happy to rephrase the entry, move it to a different sub-group, or expand the description if it would land better. Thanks for the curated list.