### PR TITLE
Add eu-vat-rates-data and vatnode to European VAT

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -433,6 +433,10 @@ All the invoicing terms & conditions are materialzed by the contract signed betw
 
 - [What does the "Reverse Charge" refer to?](https://news.ycombinator.com/item?id=8767388) - Answer: a provision in which a business transfer the responsibility of VAT handling to the customer.
 
+- [eu-vat-rates-data](https://github.com/vatnode/eu-vat-rates-data) - 🆓 Machine-readable VAT rates for 44 European countries (standard, reduced, super-reduced, parking), auto-synced daily from the European Commission's TEDB. Published to npm, PyPI, Packagist, RubyGems, and Go modules.
+
+- [vatnode](https://vatnode.dev) - EU VAT number validation API returning VIES consultation numbers, `checkId`, and `verifiedAt` for audit-ready reverse-charge invoicing.
+
 ## Invoice
 
 The invoice materialize a consumed service or purchased product, waiting to be settled by a payment transaction.


### PR DESCRIPTION
Adding two related resources to the **European VAT** subsection:

1. **[eu-vat-rates-data](https://github.com/vatnode/eu-vat-rates-data)** — MIT-licensed dataset of VAT rates for 44 European countries, auto-synced daily from the European Commission's TEDB SOAP service via GitHub Actions. Same data, idiomatic API across npm, PyPI, Packagist, RubyGems, and Go modules. Complements your own [vat-rates](https://github.com/kdeldycke/vat-rates) repo (yours is digital-services focused, this one mirrors TEDB rates 1:1 for general use).

2. **[vatnode](https://vatnode.dev)** — REST API for validating EU VAT numbers via VIES, returning the official VIES consultation number for qualified checks plus `checkId` and `verifiedAt` audit-trail fields. Most commercial VAT validation APIs (vatstack, vatlayer, abstract, vatsense) skip the consultation number — surfacing it makes reverse-charge invoices defensible at audit time.

Happy to split into two PRs, drop one, or reword if needed. Thanks for maintaining this list — it's the canonical reference for anyone going down the billing rabbit hole.