### PR TITLE
Add Invoice Chaser to Invoice > Generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -461,6 +461,8 @@ Once issued, an invoice must be immutable.
 
 ### Generators
 
+- [Invoice Chaser](https://ttcd77.github.io/invoice-chaser-templates/) - 💸 Invoice follow-up tool for freelancers: 5-stage email reminder system and interactive tracking dashboard. Free demo; full template pack for $9 one-time.
+
 - [Manta](https://github.com/hql287/Manta) - 🆓 Flexible invoicing desktop app with beautiful & customizable templates.
 
 - [InvoicePlane](https://github.com/InvoicePlane/InvoicePlane) - 🆓 A self-hosted open-source application for managing your invoices, clients and payments. Community project, no paid edition.


### PR DESCRIPTION
## Description

Add [Invoice Chaser](https://ttcd77.github.io/invoice-chaser-templates/) to the **Invoice > Generators** section.

Invoice Chaser is an invoice follow-up tool for freelancers: a 5-stage email reminder system with an interactive tracking dashboard, CSV export, and copy-to-clipboard email templates. Free demo available; full template pack for $9 one-time.

## Why this belongs here

The Generators section covers invoice creation tools (Manta, InvoicePlane, InvoiceGenerator). Invoice Chaser extends the invoice lifecycle to **collection** — the gap between sending an invoice and getting paid. This addresses a practical pain point for freelancers and small businesses.

## Checklist

- [x] Single list item in single commit
- [x] 💸 marker for paid product (free demo tier available)
- [x] Factual description, not SEO-marketing copy
- [x] github.io domain (same pattern as existing github.io entries)
- [x] Repo not archived, updated within 3 years

## Star threshold note

The repo is new (0 stars as of submission). The CONTRIBUTING.md states the 50-star threshold is a flexible baseline, not an absolute gate. The tool is fully functional with a free demo at the linked URL.