### PR TITLE
Add US State Sales Tax 2026 dataset under Taxes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -422,6 +422,7 @@ All the invoicing terms & conditions are materialzed by the contract signed betw
 - “British supermarkets (…) charge you a fee for their backend card processing, but they subtract that fee from your checkout price.” ([source](https://news.ycombinator.com/item?id=22047028)) - Which allows them to [claim the VAT on processing fees as input tax](https://www.gov.uk/guidance/vat-guide-notice-700#section4).
 
 - [Streamlined Sales Tax Governing Board](https://www.streamlinedsalestax.org/about-us/about-sstgb) - A multi-states US initiative to automate and standadize sales tax accounting and collection.
+- [US State Sales Tax 2026](https://github.com/receiptedit/us-sales-tax-2026) - Open MIT-licensed dataset of 2026 US state sales tax rates, lodging taxes (TOT, occupancy, tourism), and grocery taxation rules for all 50 states. CSV, JSON, and free public REST API.
 
 ### European VAT
 


### PR DESCRIPTION
Adding US State Sales Tax 2026 to the Taxes section — a free MIT-licensed dataset that mirrors the maintainer's own VAT Rate Database approach, but for US state sales tax.

The dataset covers all 50 US states with:
- Statewide sales tax rate
- Average combined state + local rate
- Lodging-specific taxes (TOT, occupancy, tourism assessment)
- Grocery taxation rules (exempt, reduced, or fully taxed)

Available as CSV, JSON, and free public REST API at https://github.com/receiptedit/us-sales-tax-2026

This fits the static reference material exception described in CONTRIBUTING (data sets, canonical mappings for US state tax thresholds). Sits naturally next to the existing Streamlined Sales Tax Governing Board entry as the data complement to that initiative.

License: MIT (with attribution requirement)